### PR TITLE
[15.0] c_importer_product: fix tmpl attrib values

### DIFF
--- a/connector_importer_product/components/product_product/record_handler.py
+++ b/connector_importer_product/components/product_product/record_handler.py
@@ -141,7 +141,8 @@ class ProductProductRecordHandler(Component):
                 )
             tpl_attr_values |= tpl_attr_value
         # Detect variant duplicates (same attributes)
-        combination_indices = tpl_attr_values._ids2str()
+        valid_tpl_attr_values = tpl_attr_values._without_no_variant_attributes()
+        combination_indices = valid_tpl_attr_values._ids2str()
         existing_product = self.env["product.product"].search(
             [
                 ("id", "!=", odoo_record.id),
@@ -160,7 +161,7 @@ class ProductProductRecordHandler(Component):
         # It is required to set the whole template attribute values at the end
         # (and not in the loop) to not trigger internal mechanisms done by Odoo
         else:
-            odoo_record.product_template_attribute_value_ids = tpl_attr_values
+            odoo_record.product_template_attribute_value_ids = valid_tpl_attr_values
 
     def _find_attr_value(self, orig_values, attr_column):
         """Find matching attribute value.


### PR DESCRIPTION
`prod.product_template_attribute_value_ids` must be set using _only_ valid values.
To find them, we must use `_without_no_variant_attribute()`
as Odoo does in relevant places.

`combination_indices` depends on `product_template_attribute_value_ids`,
hence if its value is wrong the index will be wrong
and you won't find the right variant.

Additionally, when using the product configurator,
since the combination is wrong
the product won't be purchase-able or sale-able w/ the configurator.


Original commit: https://github.com/camptocamp/connector-interfaces/commit/86576ba0e4086dc89ee023b7ca49477ad043bf95