### PR TITLE
BSGDE-11: Add a new barcode rule for priced product with change rate for POS

### DIFF
--- a/pos_barcode_rule_priced_with_change_rate/__init__.py
+++ b/pos_barcode_rule_priced_with_change_rate/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/pos_barcode_rule_priced_with_change_rate/__manifest__.py
+++ b/pos_barcode_rule_priced_with_change_rate/__manifest__.py
@@ -1,0 +1,20 @@
+{
+    "name": "Point of Sale - New barcode rule for priced product with change rate",
+    "version": "17.0.1.0.0",
+    "category": "Sales/Point of Sale",
+    "summary": """
+        Add a barcode rule to be able to scan a barcode with price encoded (as the 
+        standard "Priced Product" rule), and convert the price according to a given 
+        change rate.
+    """,
+    "author": "Camptocamp",
+    "depends": ["point_of_sale"],
+    "data": ["views/res_config_settings_views.xml"],
+    "assets": {
+        "point_of_sale._assets_pos": [
+            'pos_barcode_rule_priced_with_change_rate/static/src/**/*',
+        ],
+    },
+    "installable": True,
+    "license": "AGPL-3",
+}

--- a/pos_barcode_rule_priced_with_change_rate/i18n/fr.po
+++ b/pos_barcode_rule_priced_with_change_rate/i18n/fr.po
@@ -1,0 +1,47 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* gdetou_point_of_sale
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 17.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-02-01 12:58+0000\n"
+"PO-Revision-Date: 2024-02-01 12:58+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: gdetou_point_of_sale
+#: model:ir.model,name:gdetou_point_of_sale.model_barcode_rule
+msgid "Barcode Rule"
+msgstr "Règle de code-barres"
+
+#. module: gdetou_point_of_sale
+#: model:ir.model.fields,field_description:gdetou_point_of_sale.field_pos_config__change_rate_barcode
+#: model:ir.model.fields,field_description:gdetou_point_of_sale.field_res_config_settings__change_rate_barcode
+msgid "Change rate for barcode nomenclature"
+msgstr "Taux de change pour Nomenclature codes-barres"
+
+#. module: gdetou_point_of_sale
+#: model:ir.model,name:gdetou_point_of_sale.model_res_config_settings
+msgid "Config Settings"
+msgstr "Paramètres de configuration"
+
+#. module: gdetou_point_of_sale
+#: model:ir.model,name:gdetou_point_of_sale.model_pos_config
+msgid "Point of Sale Configuration"
+msgstr "Configuration du point de vente"
+
+#. module: gdetou_point_of_sale
+#: model:ir.model.fields.selection,name:gdetou_point_of_sale.selection__barcode_rule__type__price_change_rate
+msgid "Priced Product with Change Rate"
+msgstr "Produit à prix fixe avec taux de change"
+
+#. module: gdetou_point_of_sale
+#: model:ir.model.fields,field_description:gdetou_point_of_sale.field_barcode_rule__type
+msgid "Type"
+msgstr ""

--- a/pos_barcode_rule_priced_with_change_rate/models/__init__.py
+++ b/pos_barcode_rule_priced_with_change_rate/models/__init__.py
@@ -1,0 +1,3 @@
+from . import barcode_rule
+from . import pos_config
+from . import res_config_settings

--- a/pos_barcode_rule_priced_with_change_rate/models/barcode_rule.py
+++ b/pos_barcode_rule_priced_with_change_rate/models/barcode_rule.py
@@ -1,0 +1,10 @@
+# Copyright 2024 Camptocamp SA (https://www.camptocamp.com).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import models, fields
+
+
+class BarcodeRule(models.Model):
+    _inherit = 'barcode.rule'
+
+    type = fields.Selection(selection_add=[('price_change_rate', 'Priced Product with Change Rate')], ondelete={'price_change_rate': 'set default'})

--- a/pos_barcode_rule_priced_with_change_rate/models/pos_config.py
+++ b/pos_barcode_rule_priced_with_change_rate/models/pos_config.py
@@ -1,0 +1,10 @@
+# Copyright 2024 Camptocamp SA (https://www.camptocamp.com).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class PosConfig(models.Model):
+    _inherit = 'pos.config'
+
+    change_rate_barcode = fields.Float(string="Change rate for barcode nomenclature")

--- a/pos_barcode_rule_priced_with_change_rate/models/res_config_settings.py
+++ b/pos_barcode_rule_priced_with_change_rate/models/res_config_settings.py
@@ -1,0 +1,10 @@
+# Copyright 2024 Camptocamp SA (https://www.camptocamp.com).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = 'res.config.settings'
+
+    change_rate_barcode = fields.Float(related="pos_config_id.change_rate_barcode", readonly=False)

--- a/pos_barcode_rule_priced_with_change_rate/static/src/overrides/components/product_screen/product_screen.js
+++ b/pos_barcode_rule_priced_with_change_rate/static/src/overrides/components/product_screen/product_screen.js
@@ -1,0 +1,44 @@
+/** @odoo-module **/
+
+import { _t } from "@web/core/l10n/translation";
+import { ProductScreen } from "@point_of_sale/app/screens/product_screen/product_screen";
+import { useBarcodeReader } from "@point_of_sale/app/barcode/barcode_reader_hook";
+import { patch } from "@web/core/utils/patch";
+import { ConfirmPopup } from "@point_of_sale/app/utils/confirm_popup/confirm_popup";
+import { useService } from "@web/core/utils/hooks";
+
+patch(ProductScreen.prototype, {
+    setup() {
+        super.setup(...arguments);
+        useBarcodeReader({
+            price_change_rate: this._onPriceChangeRateScan,
+        });
+    },
+
+    async _onPriceChangeRateScan(code) {
+        // Read the barcode the same way than it is done for the standard `price` type (cf.
+        // https://github.com/odoo/odoo/blob/17.0/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js#L257C1-L290C6),
+        // and convert the price according to the change rate in POS settings before returning it.
+        const product = await this._getProductByBarcode(code);
+        if (!product) {
+            return this.popup.add(ErrorBarcodePopup, { code: code.base_code });
+        }
+        const options = await product.getAddProductOptions(code);
+        // Do not proceed on adding the product when no options is returned.
+        // This is consistent with clickProduct.
+        if (!options) {
+            return;
+        }
+
+        Object.assign(options, {
+            price: code.value / this.pos.config.change_rate_barcode,
+            extras: {
+                price_type: "manual",
+            },
+        });
+
+        this.currentOrder.add_product(product, options);
+        this.numberBuffer.reset();
+    },
+
+});

--- a/pos_barcode_rule_priced_with_change_rate/views/res_config_settings_views.xml
+++ b/pos_barcode_rule_priced_with_change_rate/views/res_config_settings_views.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="point_of_sale.res_config_settings_view_form"/>
+        <field name="arch" type="xml">
+            <setting id="barcode_scanner" position="inside">
+                <div class="content-group mt16 row">
+                    <label for="change_rate_barcode" class="col-lg-3 o_light_label"/>
+                    <field name="change_rate_barcode"/>
+                </div>
+            </setting>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
[BSGDE-11](https://jira.camptocamp.com/browse/BSGDE-11)

Add a barcode rule to be able to scan a barcode with price encoded (as the 
standard "Priced Product" rule), and convert the price according to a given 
change rate.